### PR TITLE
Make AT_CellularContext::get_context() virtual

### DIFF
--- a/features/cellular/framework/AT/AT_CellularContext.h
+++ b/features/cellular/framework/AT/AT_CellularContext.h
@@ -99,6 +99,9 @@ protected:
     virtual void deactivate_ip_context();
     virtual void set_disconnect();
     virtual void deactivate_context();
+    virtual bool get_context();
+    pdp_type_t string_to_pdp_type(const char *pdp_type);
+    AT_CellularBase::CellularProperty pdp_type_t_to_cellular_property(pdp_type_t pdp_type);
 private:
 #if NSAPI_PPP_AVAILABLE
     nsapi_error_t open_data_channel();
@@ -111,11 +114,8 @@ private:
     nsapi_error_t activate_ip_context();
     void check_and_deactivate_context();
     bool set_new_context(int cid);
-    bool get_context();
     nsapi_error_t delete_current_context();
-    pdp_type_t string_to_pdp_type(const char *pdp_type);
     nsapi_error_t check_operation(nsapi_error_t err, ContextOperation op);
-    AT_CellularBase::CellularProperty pdp_type_t_to_cellular_property(pdp_type_t pdp_type);
     void ciot_opt_cb(mbed::CellularNetwork::CIoT_Supported_Opt ciot_opt);
     virtual void do_connect_with_retry();
 private:


### PR DESCRIPTION
### Description

<!--
    Required
    Add here detailed changes summary, testing results, dependencies
    Good example: https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html (Pull request template)
-->
I have observed that some cell modules (namely the Telit ME910C1) pre-fill the contexts with dummy values. When the current `get_context()` function calls the `AT+CGDCONT?` command, the module responds with 6 already populated dummy contexts. For example:
```
AT+CGDCONT?<cr><cr><ln>
+CGDCONT: 1,"IPV4V6","","0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0",0,0,0,0<cr><ln>
+CGDCONT: 2,"IPV4V6","ims","0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0",0,0,0,0<cr><ln>
+CGDCONT: 3,"IPV4V6","sos","0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0",0,0,0,1<cr><ln>
+CGDCONT: 4,"IPV4V6","attm2mglobal","0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0",0,0,0,0<cr><ln>
+CGDCONT: 5,"IPV4V6","","0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0",0,0,0,0<cr><ln>
+CGDCONT: 6,"IPV4V6","","0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0",0,0,0,0<cr><ln>
<cr><ln>
OK<cr><ln>
```
I would expect the `get_context()` function to select and overwrite the 1st context, but instead cycles through all of the contexts, rejects them all (none of them match the target APN for my SIM), and tries to create a 7th. This throws then throws an error since the ME910C1 only supports 6 contexts.

Therefore, I propose making the `get_context()` function `virtual` and overwrite-able by the individual cell module driver authors (similar to what is available for other `AT_CellularContext` functions, like `do_connect()`), which is what this PR enables. 

### Pull request type

<!--
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

### Reviewers

<!--
    Optional
    Request additional reviewers with @username
-->

### Release Notes

<!--
    Optional
    In case of breaking changes, functionality changes or refactors, please add release notes here. 
    For more information, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html#pull-request-types).
-->
Makes `AT_CellularContext::get_context()` virtual
